### PR TITLE
enforcementaction in the left card

### DIFF
--- a/compliance-web/src/components/App/Inspections/Profile/Requirements/RequirementFormLeft.tsx
+++ b/compliance-web/src/components/App/Inspections/Profile/Requirements/RequirementFormLeft.tsx
@@ -84,6 +84,11 @@ const RequirementFormLeft: FC<RequirementFormLeftProps> = ({
     control,
     name: "complianceFinding",
   });
+  useEffect(() => {
+    if (enforcementAction?.id !== EnforcementActionEnum.ORDER) {
+      setValue("isReferralToAdministrativePenalty", false);
+    }
+  }, [enforcementAction]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
The bug was
- If you select only Refer to Administrative Penality it shows twice in the LeftForm in view mode