### PR TITLE
fix(compliance-api): block requirement deletion when AP is beyond Drafting (COMP-907)

### DIFF
--- a/compliance-api/src/compliance_api/services/inspection_requirement.py
+++ b/compliance-api/src/compliance_api/services/inspection_requirement.py
@@ -2213,6 +2213,13 @@ def _check_orders_and_warning_letters(requirement):
 
 
 def _check_administrative_penalties(requirement):
+    """Prevent deletion when a linked administrative penalty has progressed beyond Drafting.
+
+    Only APs in Drafting can be updated or deleted alongside the requirement;
+    any later status (Referred to AMP Unit, Deputy Review, CEB Not Proceeding,
+    Referred to DM) blocks the deletion regardless of whether the AP is
+    considered closed.
+    """
     enforcement_actions = requirement.enforcement_actions
     enforcement_action_ids = [
         action.enforcement_action_id for action in enforcement_actions
@@ -2221,10 +2228,10 @@ def _check_administrative_penalties(requirement):
         administrative_penalty_map = AdministrativePenaltyInspectionRequirementMapModel.get_by_requirement_id(
             requirement.id
         )
-        if administrative_penalty_map and (
-            administrative_penalty_map.administrative_penalty.referral_status == ReferralStatusEnum.CEB_NOT_PROCEEDING
-            or (administrative_penalty_map.administrative_penalty.referral_status == ReferralStatusEnum.REFERRED_TO_DM
-                and administrative_penalty_map.administrative_penalty.decision is not None)
+        if (
+            administrative_penalty_map
+            and administrative_penalty_map.administrative_penalty.referral_status
+            != ReferralStatusEnum.DRAFTING
         ):
             raise UnprocessableEntityError("Active administrative penalty found")
 

--- a/compliance-api/tests/integration/api/test_inspection_requirement.py
+++ b/compliance-api/tests/integration/api/test_inspection_requirement.py
@@ -5,11 +5,14 @@ import json
 from http import HTTPStatus
 from urllib.parse import urljoin
 
+import pytest
+
 from compliance_api.models import InspectionReqSourceDetail as InspectionReqSourceDetailModel
 from compliance_api.models import InspectionRequirement as InspectionRequirementModel
 from compliance_api.models import InspectionStatusEnum, RequirementSourceEnum
 from compliance_api.models.administrative_penalty import AdministrativePenalty as AdministrativePenaltyModel
 from compliance_api.models.administrative_penalty import AdministrativePenaltyInspectionRequirementMap
+from compliance_api.models.administrative_penalty import DecisionEnum, ReferralStatusEnum
 from compliance_api.models.order import Order as OrderModel
 from compliance_api.models.order import OrderInspectionRequirementMap
 from compliance_api.models.warning_letter import WarningLetter as WarningLetterModel
@@ -571,6 +574,51 @@ def test_delete_requirement_keeps_merged_draft_administrative_penalty(
         not in remaining_requirement_ids
     )
     assert second_requirement.id in remaining_requirement_ids
+
+
+@pytest.mark.parametrize(
+    "referral_status,decision",
+    [
+        (ReferralStatusEnum.REFERRED_TO_AMP_UNIT, None),
+        (ReferralStatusEnum.DEPUTY_REVIEW, None),
+        (ReferralStatusEnum.CEB_NOT_PROCEEDING, None),
+        (ReferralStatusEnum.REFERRED_TO_DM, None),
+        (ReferralStatusEnum.REFERRED_TO_DM, DecisionEnum.AP_ISSUED),
+    ],
+)
+def test_delete_requirement_blocked_when_administrative_penalty_beyond_drafting(
+    client,
+    auth_header_super_user,
+    created_inspection,
+    created_administrative_penalty,
+    created_administrative_penalty_inspection_requirement,
+    referral_status,
+    decision,
+):
+    """Deletion is blocked once the linked AP has progressed beyond Drafting."""
+    created_administrative_penalty.referral_status = referral_status
+    created_administrative_penalty.decision = decision
+    created_administrative_penalty.save()
+
+    url = urljoin(
+        API_BASE_URL,
+        f"{created_inspection.id}/requirements/"
+        f"{created_administrative_penalty_inspection_requirement.id}",
+    )
+    result = client.delete(url, headers=auth_header_super_user)
+    assert result.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+
+    # Both the requirement and the administrative penalty remain untouched.
+    assert (
+        InspectionRequirementModel.find_by_id(
+            created_administrative_penalty_inspection_requirement.id
+        )
+        is not None
+    )
+    assert (
+        AdministrativePenaltyModel.find_by_id(created_administrative_penalty.id)
+        is not None
+    )
 
 
 def test_create_requirement_with_invalid_inspection(


### PR DESCRIPTION
- Tighten _check_administrative_penalties: any linked administrative penalty with referral status other than Drafting now blocks deletion (previously only CEB Not Proceeding, or Referred to DM with a decision)