### PR TITLE
fix(api): validate relative_url before presigned S3 calls (COMP-883)

### DIFF
--- a/compliance-api/src/compliance_api/schemas/inspection_requirement.py
+++ b/compliance-api/src/compliance_api/schemas/inspection_requirement.py
@@ -22,11 +22,18 @@ from compliance_api.models.inspection.inspection_req_detail_doc_image import Ins
 from compliance_api.models.inspection.inspection_req_detail_image import InspectionRequirementDetailImage
 from compliance_api.models.requirement_source import RequirementSourceEnum
 from compliance_api.utils.constant import INPUT_DATE_TIME_FORMAT
+from compliance_api.utils.storage_key import is_valid_relative_url
 
 from .appendix import AppendixSchema
 from .base_schema import AutoSchemaBase, BaseSchema
 from .common import KeyValueSchema
 from .staff_user import StaffUserSchema
+
+
+def _validate_relative_url(value):
+    """Validate that relative_url is a safe, expected storage key."""
+    if not is_valid_relative_url(value):
+        raise ValidationError("Invalid storage key for relative_url")
 
 
 class InspectionReqImageCreateSchema(BaseSchema):
@@ -71,6 +78,7 @@ class InspectionReqImageCreateSchema(BaseSchema):
     relative_url = fields.Str(
         metadata={"description": "The relative url of the final uploaded image"},
         required=True,
+        validate=_validate_relative_url,
     )
 
 
@@ -95,6 +103,7 @@ class InspectionReqDetailImageCreateSchema(BaseSchema):
     relative_url = fields.Str(
         metadata={"description": "The actual url of the final uploaded image"},
         required=True,
+        validate=_validate_relative_url,
     )
 
 
@@ -118,6 +127,7 @@ class InspectionReqDetailDocImageCreateSchema(BaseSchema):
     relative_url = fields.Str(
         metadata={"description": "The actual url of the final uploaded image"},
         required=True,
+        validate=_validate_relative_url,
     )
 
 

--- a/compliance-api/src/compliance_api/services/document_service/doc_service.py
+++ b/compliance-api/src/compliance_api/services/document_service/doc_service.py
@@ -6,6 +6,7 @@ from tenacity import RetryError, retry, retry_if_exception_type, stop_after_atte
 
 from compliance_api.exceptions import BadRequestError, PermissionDeniedError, ServiceUnavailableError
 from compliance_api.utils.enum import HttpMethod
+from compliance_api.utils.storage_key import is_valid_relative_url
 
 from .constant import API_REQUEST_TIMEOUT
 
@@ -16,6 +17,8 @@ class DocService:
     @staticmethod
     def get_presigned_url(payload: dict, params: dict = None) -> dict:
         """Get presigned url for the given action on the given file."""
+        if not is_valid_relative_url(payload.get("relative_url")):
+            raise BadRequestError("Invalid storage key for relative_url")
         try:
             response = _request_doc_service(
                 "storage-operations/presigned-urls", HttpMethod.POST, payload, params

--- a/compliance-api/src/compliance_api/utils/storage_key.py
+++ b/compliance-api/src/compliance_api/utils/storage_key.py
@@ -1,0 +1,41 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validation for user-supplied cloud storage keys (relative_url).
+
+Guards against path traversal: relative_url is forwarded to the document
+service to mint presigned GET/PUT/DELETE URLs, so an unvalidated value could
+be used to read, overwrite, or delete objects outside the caller's own prefix.
+"""
+import re
+
+# Prefixes under which this API ever writes objects: "compliance/" for
+# client-uploaded images, "inspection_records/" for server-generated reports.
+ALLOWED_RELATIVE_URL_PREFIXES = ("compliance/", "inspection_records/")
+
+# Restrict to a safe character set in addition to the prefix/traversal checks
+# below, so encoded traversal sequences or backslashes can't sneak through.
+_SAFE_RELATIVE_URL_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+
+def is_valid_relative_url(relative_url: str) -> bool:
+    """Return True if relative_url is a safe, expected storage key."""
+    if not relative_url or not isinstance(relative_url, str):
+        return False
+    if ".." in relative_url or "\\" in relative_url:
+        return False
+    if relative_url.startswith("/"):
+        return False
+    if not _SAFE_RELATIVE_URL_PATTERN.match(relative_url):
+        return False
+    return relative_url.startswith(ALLOWED_RELATIVE_URL_PREFIXES)

--- a/compliance-api/tests/unit/utils/test_storage_key.py
+++ b/compliance-api/tests/unit/utils/test_storage_key.py
@@ -1,0 +1,55 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the relative_url storage key validator.
+
+Test-Suite to ensure path traversal and other malicious storage keys are
+rejected before being forwarded to the document service.
+"""
+import pytest
+
+from compliance_api.utils.storage_key import is_valid_relative_url
+
+
+class TestIsValidRelativeUrl:
+    """Test is_valid_relative_url function."""
+
+    @pytest.mark.parametrize(
+        "relative_url",
+        [
+            "compliance/1/inspection/1/requirement_images/filename1.jpg",
+            "compliance/inspections/42/requirements-images/photo.png",
+            "inspection_records/abcdef1234567890.pdf",
+        ],
+    )
+    def test_accepts_expected_keys(self, relative_url):
+        """Test that well-formed keys under an allowed prefix are accepted."""
+        assert is_valid_relative_url(relative_url) is True
+
+    @pytest.mark.parametrize(
+        "relative_url",
+        [
+            "../../other_prefix/secret.pdf",
+            "compliance/../../../etc/passwd",
+            "compliance/1/../../secret.pdf",
+            "/compliance/1/requirement_images/filename1.jpg",
+            "compliance\\1\\requirement_images\\filename1.jpg",
+            "documents/not_allowed_prefix.pdf",
+            "",
+            None,
+        ],
+    )
+    def test_rejects_malicious_or_unexpected_keys(self, relative_url):
+        """Test that traversal, backslashes, leading slashes, and unknown prefixes are rejected."""
+        assert is_valid_relative_url(relative_url) is False

--- a/compliance-api/tests/utilities/factory_scenario/inspection_requirement_scenario.py
+++ b/compliance-api/tests/utilities/factory_scenario/inspection_requirement_scenario.py
@@ -22,7 +22,7 @@ class InspectionRequirementScenario(Enum):
                 "taken_by_id": 1,
                 "sort_order": 1,
                 "caption": "caption 1",
-                "relative_url": "/compliance/1/inspection/1/requirement_images/filename1.jpg",
+                "relative_url": "compliance/1/inspection/1/requirement_images/filename1.jpg",
             },
             {
                 "original_file_name": "filename2.jpg",
@@ -30,7 +30,7 @@ class InspectionRequirementScenario(Enum):
                 "taken_by_id": 1,
                 "sort_order": 2,
                 "caption": "caption 2",
-                "relative_url": "/compliance/1/inspection/1/requirement_images/filename2.jpg",
+                "relative_url": "compliance/1/inspection/1/requirement_images/filename2.jpg",
             },
         ],
         "figures": [
@@ -40,7 +40,7 @@ class InspectionRequirementScenario(Enum):
                 "taken_by_id": 1,
                 "caption": "caption 1",
                 "sort_order": 1,
-                "relative_url": "/compliance/1/inspection/1/requirement_images/filename3.jpg",
+                "relative_url": "compliance/1/inspection/1/requirement_images/filename3.jpg",
             },
             {
                 "original_file_name": "filename4.jpg",
@@ -48,7 +48,7 @@ class InspectionRequirementScenario(Enum):
                 "taken_by_id": 1,
                 "caption": "caption 2",
                 "sort_order": 2,
-                "relative_url": "/compliance/1/inspection/1/requirement_images/filename4.jpg",
+                "relative_url": "compliance/1/inspection/1/requirement_images/filename4.jpg",
             },
         ],
         "requirement_source_details": [
@@ -71,11 +71,11 @@ class InspectionRequirementScenario(Enum):
                 "images": [
                     {
                         "original_file_name": "source_detail_image1.jpg",
-                        "relative_url": "/compliance/1/inspection/1/req_detail_images/source_detail_image1.jpg",
+                        "relative_url": "compliance/1/inspection/1/req_detail_images/source_detail_image1.jpg",
                     },
                     {
                         "original_file_name": "source_detail_image2.png",
-                        "relative_url": "/compliance/1/inspection/1/req_detail_images/source_detail_image2.png",
+                        "relative_url": "compliance/1/inspection/1/req_detail_images/source_detail_image2.png",
                     },
                 ],
             }
@@ -115,7 +115,7 @@ class InspectionRequirementScenario(Enum):
                 "taken_by_id": 1,
                 "sort_order": 1,
                 "caption": "caption 1",
-                "relative_url": "/compliance/1/inspection/1/requirement_images/filename1.jpg",
+                "relative_url": "compliance/1/inspection/1/requirement_images/filename1.jpg",
             }
         ],
         "figures": [
@@ -125,7 +125,7 @@ class InspectionRequirementScenario(Enum):
                 "taken_by_id": 1,
                 "sort_order": 1,
                 "caption": "caption 1",
-                "relative_url": "/compliance/1/inspection/1/requirement_images/filename1.jpg",
+                "relative_url": "compliance/1/inspection/1/requirement_images/filename1.jpg",
             }
         ],
     }
@@ -157,15 +157,15 @@ class InspectionRequirementScenario(Enum):
                 "images": [
                     {
                         "original_file_name": "detail_evidence1.jpg",
-                        "relative_url": "/compliance/1/inspection/1/req_detail_images/detail_evidence1.jpg",
+                        "relative_url": "compliance/1/inspection/1/req_detail_images/detail_evidence1.jpg",
                     },
                     {
                         "original_file_name": "detail_evidence2.png",
-                        "relative_url": "/compliance/1/inspection/1/req_detail_images/detail_evidence2.png",
+                        "relative_url": "compliance/1/inspection/1/req_detail_images/detail_evidence2.png",
                     },
                     {
                         "original_file_name": "detail_evidence3.pdf",
-                        "relative_url": "/compliance/1/inspection/1/req_detail_images/detail_evidence3.pdf",
+                        "relative_url": "compliance/1/inspection/1/req_detail_images/detail_evidence3.pdf",
                     },
                 ],
             },
@@ -184,7 +184,7 @@ class InspectionRequirementScenario(Enum):
                 "images": [
                     {
                         "original_file_name": "regulation_image.jpg",
-                        "relative_url": "/compliance/1/inspection/1/req_detail_images/regulation_image.jpg",
+                        "relative_url": "compliance/1/inspection/1/req_detail_images/regulation_image.jpg",
                     }
                 ],
             },


### PR DESCRIPTION
Add is_valid_relative_url() and route it through both the schema layer (InspectionReqImage/DetailImage/DetailDocImage create schemas) and the single DocService.get_presigned_url() choke point that every GET/PUT/ DELETE presigned-URL request funnels through. Rejects path traversal (..), backslashes, leading slashes, and anything outside the expected compliance/ and inspection_records/ key prefixes, closing a path where a user-supplied relative_url could be used to read, overwrite, or delete arbitrary objects in the storage bucket.

Also fix inspection requirement test fixtures that used a leading slash in relative_url (not how the frontend actually generates keys) and add unit tests for the validator.

Ref COMP-883