### PR TITLE
fix(compliance-api): display continuation report timestamps in Pacific time (COMP-908)

### DIFF
--- a/compliance-api/src/compliance_api/services/continuation_report.py
+++ b/compliance-api/src/compliance_api/services/continuation_report.py
@@ -1,6 +1,7 @@
 """ContinuationReport Service."""
 
 from io import BytesIO
+from zoneinfo import ZoneInfo
 
 from flask import g
 
@@ -210,8 +211,12 @@ def _get_report_data(case_file):
         ),
         "continuation_report_entries": [
             {
-                "date": entry.date_created.strftime("%Y-%m-%d"),
-                "time": entry.date_created.strftime("%H:%M"),
+                "date": entry.date_created.astimezone(
+                    ZoneInfo("America/Los_Angeles")
+                ).strftime("%Y-%m-%d"),
+                "time": entry.date_created.astimezone(
+                    ZoneInfo("America/Los_Angeles")
+                ).strftime("%H:%M"),
                 "action": _build_action_text(entry),
             }
             for entry in continuation_report


### PR DESCRIPTION
Convert entry date_created to America/Los_Angeles before formatting date and time fields.

Ref #COMP-908