### PR TITLE
fix(IR): preserve report preview layout after sanitizing (COMP-882)

### DIFF
--- a/compliance-web/src/components/App/Inspections/Profile/Reports/ReportPreviewModal.tsx
+++ b/compliance-web/src/components/App/Inspections/Profile/Reports/ReportPreviewModal.tsx
@@ -1,7 +1,7 @@
 import { Box, DialogContent } from "@mui/material";
 import { FC } from "react";
 import ModalTitleBar from "@/components/Shared/Modals/ModalTitleBar";
-import { sanitizeHtml } from "@/utils/sanitizeHtml";
+import { sanitizeReportHtml } from "@/utils/sanitizeHtml";
 
 type ReportPreviewModalProps = {
   previewHtml: string;
@@ -19,7 +19,7 @@ const ReportPreviewModal: FC<ReportPreviewModalProps> = ({ previewHtml }) => {
               overflow: "auto",
               "& img": { maxWidth: "100%" },
             }}
-            dangerouslySetInnerHTML={{ __html: sanitizeHtml(previewHtml) }}
+            dangerouslySetInnerHTML={{ __html: sanitizeReportHtml(previewHtml) }}
           />
         ) : (
           <Box

--- a/compliance-web/src/utils/sanitizeHtml.test.ts
+++ b/compliance-web/src/utils/sanitizeHtml.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { sanitizeHtml } from "./sanitizeHtml";
+import { sanitizeHtml, sanitizeReportHtml } from "./sanitizeHtml";
 
 describe("sanitizeHtml", () => {
   it("strips script tags", () => {
@@ -22,5 +22,44 @@ describe("sanitizeHtml", () => {
   it("preserves allow-listed formatting tags and attributes", () => {
     const html = '<p style="color: red;"><strong>Bold</strong> and <em>italic</em></p>';
     expect(sanitizeHtml(html)).toBe(html);
+  });
+});
+
+describe("sanitizeReportHtml", () => {
+  const doc = (body: string) =>
+    `<!DOCTYPE html><html><head><title>t</title><style>table{border:1px solid black}</style></head><body>${body}</body></html>`;
+
+  it("preserves the document's style block and table layout", () => {
+    const result = sanitizeReportHtml(
+      doc('<table><colgroup><col style="width:92px"></colgroup><tr><th>A</th></tr></table>')
+    );
+    expect(result).toContain("<style>table{border:1px solid black}</style>");
+    expect(result).toContain("<colgroup>");
+    expect(result).toContain('<col style="width:92px">');
+  });
+
+  it("strips script tags", () => {
+    const result = sanitizeReportHtml(doc("<script>alert(1)</script>"));
+    expect(result).not.toContain("<script");
+    expect(result).not.toContain("alert(1)");
+  });
+
+  it("strips onerror event handler payloads from img tags", () => {
+    const result = sanitizeReportHtml(doc('<img src="x" onerror="alert(1)">'));
+    expect(result).not.toContain("onerror");
+  });
+
+  it("strips javascript: URIs from links", () => {
+    const result = sanitizeReportHtml(doc('<a href="javascript:alert(1)">click</a>'));
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("strips iframe, object, and form elements", () => {
+    const result = sanitizeReportHtml(
+      doc('<iframe src="https://evil.com"></iframe><object data="https://evil.com"></object><form action="https://evil.com"><input></form>')
+    );
+    expect(result).not.toContain("<iframe");
+    expect(result).not.toContain("<object");
+    expect(result).not.toContain("<form");
   });
 });

--- a/compliance-web/src/utils/sanitizeHtml.ts
+++ b/compliance-web/src/utils/sanitizeHtml.ts
@@ -27,3 +27,20 @@ export const sanitizeHtml = (html: string): string => {
     ALLOW_DATA_ATTR: true,
   });
 };
+
+/**
+ * Sanitizes a full HTML *document* (doctype/html/head/body, <style>,
+ * <colgroup>/<col>) as returned by epic.document for the report preview.
+ * Unlike sanitizeHtml(), this keeps the document's own layout/print CSS
+ * intact instead of applying the formatting-tag allow-list meant for
+ * small editor-authored fragments. DOMPurify still unconditionally strips
+ * <script>, event handler attributes, and javascript: URIs; the extra
+ * FORBID_TAGS remove other executable/navigable elements the default
+ * profile would otherwise keep (iframe, object, embed, form, etc.).
+ */
+export const sanitizeReportHtml = (html: string): string => {
+  return DOMPurify.sanitize(html, {
+    WHOLE_DOCUMENT: true,
+    FORBID_TAGS: ["iframe", "object", "embed", "form", "base", "link", "meta"],
+  });
+};


### PR DESCRIPTION
Add sanitizeReportHtml(), a WHOLE_DOCUMENT-mode DOMPurify sanitizer for the full HTML documents epic.document returns for the report preview. The strict per-field allow-list used elsewhere was stripping the document's <style> block and <colgroup>/<col> width hints, breaking table borders and layout in ReportPreviewModal. script tags, event handler attributes, and javascript: URIs are still stripped unconditionally, with iframe/object/embed/form/base/link/meta explicitly forbidden as well.

Ref COMP-882