### PR TITLE
fix(IR-docx): close doc-gen job races and stray errors (COMP-788)

### DIFF
--- a/compliance-api/migrations/versions/a3f9c1d24b77_unique_active_document_job_per_user.py
+++ b/compliance-api/migrations/versions/a3f9c1d24b77_unique_active_document_job_per_user.py
@@ -1,0 +1,32 @@
+"""enforce single active in-progress document job per user/inspection/format
+
+Revision ID: a3f9c1d24b77
+Revises: f9ce82110047
+Create Date: 2026-07-24 17:00:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a3f9c1d24b77'
+down_revision = 'f9ce82110047'
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = 'uq_document_jobs_active_in_progress'
+
+
+def upgrade():
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX {INDEX_NAME}
+        ON document_jobs (user_id, inspection_record_id, output_format)
+        WHERE is_active = true AND is_deleted = false AND status = 'In Progress'
+        """
+    )
+
+
+def downgrade():
+    op.execute(f"DROP INDEX {INDEX_NAME}")

--- a/compliance-api/src/compliance_api/resources/inspection_record.py
+++ b/compliance-api/src/compliance_api/resources/inspection_record.py
@@ -303,32 +303,37 @@ class InspectionRecordPreview(Resource):
         if output_format in ("pdf", "docx"):
             inspection = ServiceUtils.inspection_exist_check(inspection_id)
             ServiceUtils.access_check_update_for_inspection(inspection)
-            DocumentJobService.invalidate_all_previous_documents_for_user(
-                staff_user_id, inspection_record_id, output_format
+            document_job, created = DocumentJobService.start_job(
+                staff_user_id,
+                inspection_record_id,
+                output_format,
+                {
+                    "user_id": staff_user_id,
+                    "inspection_record_id": inspection_record_id,
+                    "status": DocumentJobStatusEnum.IN_PROGRESS.value,
+                    "output_format": output_format,
+                    "started_at": datetime.now(timezone.utc),
+                },
             )
-            document_job = DocumentJobService.create({
-                "user_id": staff_user_id,
-                "inspection_record_id": inspection_record_id,
-                "status": DocumentJobStatusEnum.IN_PROGRESS.value,
-                "output_format": output_format,
-                "started_at": datetime.now(timezone.utc),
-            })
-            access_token = getattr(g, "access_token", None)
-            jwt_oidc_token_info = getattr(g, "jwt_oidc_token_info", None)
-            thread = threading.Thread(
-                target=DocumentJobService.handle_background_job,
-                args=(
-                    current_app._get_current_object(),  # pylint: disable=protected-access
-                    document_job.id,
-                    access_token,
-                    jwt_oidc_token_info,
-                    inspection_id,
-                    inspection_record_id,
-                    staff_user_id,
-                    output_format,
-                ),
-            )
-            thread.start()
+            # A concurrent request already created and is rendering this job -
+            # don't start a second background render for the same job id.
+            if created:
+                access_token = getattr(g, "access_token", None)
+                jwt_oidc_token_info = getattr(g, "jwt_oidc_token_info", None)
+                thread = threading.Thread(
+                    target=DocumentJobService.handle_background_job,
+                    args=(
+                        current_app._get_current_object(),  # pylint: disable=protected-access
+                        document_job.id,
+                        access_token,
+                        jwt_oidc_token_info,
+                        inspection_id,
+                        inspection_record_id,
+                        staff_user_id,
+                        output_format,
+                    ),
+                )
+                thread.start()
             return DocumentJobSchema().dump(document_job), HTTPStatus.ACCEPTED
 
         # Handle HTML format (default)

--- a/compliance-api/src/compliance_api/services/document_job.py
+++ b/compliance-api/src/compliance_api/services/document_job.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 
 import requests
 from flask import current_app
+from sqlalchemy.exc import IntegrityError
 
 from compliance_api.exceptions import BusinessError, ResourceNotFoundError, UnprocessableEntityError
 from compliance_api.models.document_job import DocumentJob, DocumentJobStatusEnum
@@ -22,14 +23,39 @@ class DocumentJobService:
         return document_job.save()
 
     @staticmethod
+    def start_job(staff_user_id, inspection_record_id, output_format, document_job_data):
+        """Invalidate any previous job and create a new one.
+
+        Returns ``(document_job, created)``. A DB-level partial unique index
+        allows at most one active IN_PROGRESS job per (user, inspection_record,
+        output_format), so two near-simultaneous requests (e.g. a double-click
+        before the UI disables the generate button) can't both create a job:
+        the second one loses the race with an IntegrityError, and this returns
+        the job the first request already created instead, with ``created``
+        false so the caller knows not to spawn a second background render for
+        the same job.
+        """
+        DocumentJobService.invalidate_all_previous_documents_for_user(
+            staff_user_id, inspection_record_id, output_format
+        )
+        try:
+            return DocumentJobService.create(document_job_data), True
+        except IntegrityError:
+            existing = DocumentJobService.get_most_recent_document_job_for_user(
+                staff_user_id, inspection_record_id, output_format
+            )
+            return existing, False
+
+    @staticmethod
     def get_most_recent_document_job_for_user(user_id, inspection_record_id, output_format):
         """Get the most recently generated document for a user."""
-        jobs = DocumentJob.get_by_params({
-            "user_id": user_id,
-            "inspection_record_id": inspection_record_id,
-            "output_format": output_format,
-        })
-        return jobs[-1] if jobs else None
+        return DocumentJob.query.filter_by(
+            user_id=user_id,
+            inspection_record_id=inspection_record_id,
+            output_format=output_format,
+            is_active=True,
+            is_deleted=False,
+        ).order_by(DocumentJob.id.desc()).first()
 
     @staticmethod
     def get_last_generated_time_for_user(user_id, inspection_record_id, output_format):
@@ -44,33 +70,58 @@ class DocumentJobService:
 
     @staticmethod
     def update(document_job_id, user_id, update_data):
-        """Update a document job by its ID."""
-        document_job = DocumentJob.get_by_params({
-            "id": document_job_id,
-            "user_id": user_id,
-        })
-        document_job = document_job[0] if document_job else None
+        """Update a document job by its ID.
+
+        Idempotent: a job already invalidated (e.g. by
+        ``invalidate_all_previous_documents_for_user`` racing with this call)
+        is treated as a no-op success rather than a 404. Also refuses to
+        downgrade an already-COMPLETED job to FAILED, which guards against
+        the frontend's "stuck job" watchdog racing the background thread's
+        own completion update.
+        """
+        document_job = DocumentJob.query.filter_by(
+            id=document_job_id,
+            user_id=user_id,
+        ).first()
+
         if not document_job:
             raise ResourceNotFoundError(
                 f"Document Job with id: {document_job_id} not found"
             )
+
+        if document_job.is_deleted:
+            return document_job
+
+        if (
+            update_data.get("status") == DocumentJobStatusEnum.FAILED.value
+            and document_job.status == DocumentJobStatusEnum.COMPLETED.value
+        ):
+            return document_job
+
         document_job.update(update_data)
         return document_job
 
     @staticmethod
     def delete(document_job_id, user_id):
-        """Delete a document job by its ID."""
-        document_job = DocumentJob.get_by_params({
-            "id": document_job_id,
-            "user_id": user_id
-        })
+        """Delete a document job by its ID.
+
+        Idempotent: a job already deleted (e.g. by
+        ``invalidate_all_previous_documents_for_user`` racing with this call)
+        is treated as a no-op success rather than a 404, since the desired
+        end state - the job being deleted - already holds.
+        """
+        document_job = DocumentJob.query.filter_by(
+            id=document_job_id,
+            user_id=user_id,
+        ).first()
 
         if not document_job:
             raise ResourceNotFoundError(
                 f"Document Job with id: {document_job_id} not found"
             )
 
-        document_job = document_job[0]
+        if document_job.is_deleted:
+            return document_job
 
         document_job.update({
             "is_active": False,

--- a/compliance-web/src/components/App/Inspections/Profile/Reports/PreviewDownloadButton.tsx
+++ b/compliance-web/src/components/App/Inspections/Profile/Reports/PreviewDownloadButton.tsx
@@ -30,7 +30,6 @@ import { InspectionStatusEnum } from "@/utils/constants";
 import { AxiosError } from "axios";
 import { notify } from "@/store/snackbarStore";
 import {
-  useDeleteDocumentJobs,
   useLastGeneratedTimeForUser,
   useMostRecentDocumentJobForUser,
 } from "@/hooks/useDocumentJobs";
@@ -55,6 +54,7 @@ const PreviewDownloadButton = () => {
   const lastGeneratedTime = lastGeneratedTimeObj?.last_generated_time;
 
   const [previewClicked, setPreviewClicked] = useState(false);
+  const [docxSubmitting, setDocxSubmitting] = useState(false);
   const [open, setOpen] = useState(false);
   const anchorRef = useRef<HTMLDivElement>(null);
   const currentUser = useCurrentLoggedInUser();
@@ -102,8 +102,8 @@ const PreviewDownloadButton = () => {
   );
 
   const isGenerating = useMemo(() => {
-    return documentJob?.status === DocumentJobStatus.IN_PROGRESS;
-  }, [documentJob]);
+    return docxSubmitting || documentJob?.status === DocumentJobStatus.IN_PROGRESS;
+  }, [docxSubmitting, documentJob]);
 
   const isCompleted = useMemo(() => {
     return documentJob?.status === DocumentJobStatus.COMPLETED;
@@ -119,26 +119,17 @@ const PreviewDownloadButton = () => {
   };
 
   const queryClient = useQueryClient();
-  const { mutate: mutateDeleteDocumentJob } = useDeleteDocumentJobs();
 
   const handleGenerateDocx = async (event: MouseEvent) => {
     handleClose(event);
 
-    // Generating a new report invalidates the previous one
-    if (documentJob?.id) {
-      mutateDeleteDocumentJob(documentJob.id, {
-        onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: [
-              "mostRecentDocumentJob",
-              inspectionReportsData?.id,
-              "docx",
-            ],
-          });
-        },
-      });
+    if (docxSubmitting) {
+      return;
     }
+    setDocxSubmitting(true);
 
+    // The backend invalidates the previous job for this user/inspection/format
+    // as part of creating the new one.
     mutateIrPreviewData(
       {
         inspectionId: inspectionData?.id ?? 0,
@@ -147,6 +138,7 @@ const PreviewDownloadButton = () => {
       },
       {
         onSuccess: () => {
+          setDocxSubmitting(false);
           queryClient.invalidateQueries({
             queryKey: [
               "mostRecentDocumentJob",
@@ -154,6 +146,9 @@ const PreviewDownloadButton = () => {
               "docx",
             ],
           });
+        },
+        onError: () => {
+          setDocxSubmitting(false);
         },
       }
     );

--- a/compliance-web/src/hooks/useDocumentJobs.tsx
+++ b/compliance-web/src/hooks/useDocumentJobs.tsx
@@ -1,6 +1,7 @@
 import { DocumentJob, DocumentJobStatus } from "@/models/documentJob";
-import { request } from "@/utils/axiosUtils";
+import { request, requestSilent } from "@/utils/axiosUtils";
 import { useQuery, useMutation } from "@tanstack/react-query";
+import { useRef } from "react";
 
 const fetchMostRecentDocumentJobForUser = (
   inspectionReportID: number,
@@ -22,14 +23,14 @@ const fetchLastGeneratedTimeForUser = (
   });
 };
 
-const updateDocumentJob = (
-  jobId: string,
-  data: Partial<DocumentJob>
-): Promise<DocumentJob> => {
-  return request({
+// Used only by the background "stuck job" watchdog below - silent because
+// the user never triggered this call directly, so a failure shouldn't
+// surface as an error toast.
+const markDocumentJobFailedSilently = (jobId: string): Promise<DocumentJob> => {
+  return requestSilent({
     url: `/document-jobs/${jobId}`,
     method: "PUT",
-    data,
+    data: { status: DocumentJobStatus.FAILED },
   });
 };
 
@@ -44,6 +45,8 @@ export const useMostRecentDocumentJobForUser = (
   inspectionReportID: number,
   outputFormat: "pdf" | "docx" = "pdf"
 ) => {
+  const watchdogFiredRef = useRef(new Set<string>());
+
   return useQuery<DocumentJob, Error>({
     queryKey: ["mostRecentDocumentJob", inspectionReportID, outputFormat],
     queryFn: () =>
@@ -60,12 +63,16 @@ export const useMostRecentDocumentJobForUser = (
         const now = new Date().getTime();
         const elapsed = now - startedAt;
         const allowedWaitTime = 10 * 60 * 1000; // 10 minutes
-        // If the job has been in progress for more than 10 minutes, mark it as failed and stop polling
-        if (elapsed > allowedWaitTime && query.state.data?.id) {
-          updateDocumentJob(query.state.data.id, {
-            status: DocumentJobStatus.FAILED,
-          }).then(() => {
-            return false;
+        // If the job has been in progress for more than 10 minutes, mark it as failed.
+        // Only fire once per stale job, and re-check the status right before writing
+        if (
+          elapsed > allowedWaitTime &&
+          query.state.data?.id &&
+          !watchdogFiredRef.current.has(query.state.data.id)
+        ) {
+          watchdogFiredRef.current.add(query.state.data.id);
+          markDocumentJobFailedSilently(query.state.data.id).catch(() => {
+            // A failure here isn't user-actionable, so make it silent.
           });
         }
       }

--- a/compliance-web/src/utils/axiosUtils.ts
+++ b/compliance-web/src/utils/axiosUtils.ts
@@ -93,6 +93,11 @@ export const requestDocumentAPI = ({ ...options }) => {
   return documentAPIClient(options).then(onSuccess).catch(onError);
 };
 
+// Skips the global error toast - for background/housekeeping calls the user didn't trigger
+export const requestSilent = ({ ...options }) => {
+  return apiClient(options).then(onSuccess);
+};
+
 export const requestAxios = ({ ...options }) => {
   const client = axios.create(options);
   return client(options).then(onSuccess).catch(onError);


### PR DESCRIPTION
Regenerating a DOCX/PDF report while a previous job for the same user/inspection/format was still in flight could produce intermittent 404s and error toasts:

- Removed the redundant client-side DELETE on regenerate; the backend already invalidates the previous job when the new render request comes in, so the two calls no longer race each other.
- Made DocumentJobService.update/delete idempotent: an already invalidated job is a no-op instead of a 404, and update() refuses to downgrade a COMPLETED job to FAILED (guards against the frontend's stale-job watchdog racing the background render thread's own completion update).
- Fixed get_most_recent_document_job_for_user to explicitly order by id instead of relying on unordered query results.
- Added a DB-level partial unique index so at most one IN_PROGRESS job can exist per (user, inspection_record, output_format); a losing concurrent request (e.g. a double-click) now returns the winner's job instead of erroring, and no longer spawns a duplicate render thread.
- Added a local submitting guard on the Generate button so it disables immediately on click rather than only after the server confirms IN_PROGRESS.
- Added requestSilent so the background stale-job watchdog no longer surfaces a user-facing error toast for internal housekeeping failures.

Ref COMP-788