### PR TITLE
fix(compliance-api,compliance-web): guard ir_progress writes (COMP-910)

### DIFF
--- a/compliance-api/src/compliance_api/resources/inspection_record.py
+++ b/compliance-api/src/compliance_api/resources/inspection_record.py
@@ -155,6 +155,30 @@ class InspectionRecordFinal(Resource):
         return InspectionRecordSchema().dump(final_ir), HTTPStatus.OK
 
 
+@cors_preflight("PATCH, OPTIONS")
+@API.route(
+    "/<int:inspection_record_id>/continue-preliminary-review",
+    methods=["PATCH", "OPTIONS"],
+)
+class InspectionRecordContinuePreliminaryReview(Resource):
+    """Resource to send an IR back to preliminary drafting for another review round."""
+
+    @staticmethod
+    @API.response(code=200, description="Sucess", model=ir_list_model)
+    @ApiHelper.swagger_decorators(
+        API, endpoint_description="Continue another round of preliminary review"
+    )
+    @API.response(404, "Not Found")
+    @API.response(422, "Unprocessable Entity")
+    @auth.require
+    def patch(inspection_id, inspection_record_id):
+        """Send IR back to PRELIMINARY_DRAFTING."""
+        updated_ir = InspectionRecordService.continue_preliminary_review(
+            inspection_id, inspection_record_id
+        )
+        return InspectionRecordSchema().dump(updated_ir), HTTPStatus.OK
+
+
 @cors_preflight("GET, OPTIONS, POST, PATCH")
 @API.route("/<int:inspection_record_id>/approvals", methods=["POST", "GET", "OPTIONS"])
 class InspectionRecordApprovals(Resource):
@@ -222,6 +246,30 @@ class InspectionRecordApproval(Resource):
             inspection_id, inspection_record_id, approval_id, approval_update_data
         )
         return InspectionRecordApprovalSchema().dump(updated_approval), HTTPStatus.OK
+
+
+@cors_preflight("OPTIONS, PATCH")
+@API.route(
+    "/<int:inspection_record_id>/approvals/<int:approval_id>/reopen",
+    methods=["PATCH", "OPTIONS"],
+)
+class InspectionRecordApprovalReopen(Resource):
+    """Resource to atomically reopen an approved inspection record."""
+
+    @staticmethod
+    @API.response(code=200, description="Success", model=ir_list_model)
+    @ApiHelper.swagger_decorators(
+        API, endpoint_description="Reopen an approved inspection record"
+    )
+    @API.response(404, "Not Found")
+    @API.response(422, "Unprocessable Entity")
+    @auth.require
+    def patch(inspection_id, inspection_record_id, approval_id):
+        """Reopen an approved inspection record."""
+        reopened_ir = InspectionRecordApprovalService.reopen(
+            inspection_id, inspection_record_id, approval_id
+        )
+        return InspectionRecordSchema().dump(reopened_ir), HTTPStatus.OK
 
 
 @cors_preflight("OPTIONS, PATCH, GET")

--- a/compliance-api/src/compliance_api/schemas/inspection_record.py
+++ b/compliance-api/src/compliance_api/schemas/inspection_record.py
@@ -4,7 +4,7 @@ from marshmallow import EXCLUDE, ValidationError, fields, post_dump, post_load, 
 from marshmallow_enum import EnumField
 
 from compliance_api.models.inspection_record import InspectionRecord as InspectionRecordModel
-from compliance_api.models.inspection_record import IRProgressEnum, IRStatusEnum
+from compliance_api.models.inspection_record import IRStatusEnum
 from compliance_api.utils.constant import INPUT_DATE_TIME_FORMAT
 
 from .base_schema import AutoSchemaBase, BaseSchema
@@ -75,7 +75,6 @@ class UpdateInspectionRecordSchema(BaseSchema):
             "action_required_by_rp": fields.Str(),
             "record_prepared_by_id": fields.Int(),
             "record_prepared_by_position_id": fields.Int(),
-            "ir_progress": EnumField(IRProgressEnum, by_value=False),
             "date_issued": fields.DateTime(
                 format=INPUT_DATE_TIME_FORMAT,
                 metadata={

--- a/compliance-api/src/compliance_api/services/inspection_record/inspection_record.py
+++ b/compliance-api/src/compliance_api/services/inspection_record/inspection_record.py
@@ -221,6 +221,31 @@ class InspectionRecordService:
         return updated_ir
 
     @classmethod
+    def continue_preliminary_review(cls, inspection_id, inspection_record_id):
+        """Send an IR back to PRELIMINARY_DRAFTING for another round of preliminary review."""
+        inspection = ServiceUtils.inspection_exist_check(inspection_id)
+        inspection_record = ServiceUtils.inspection_record_exist_check(
+            inspection_record_id
+        )
+        ServiceUtils.access_check_update_for_inspection(inspection)
+        ServiceUtils.inspection_status_check(inspection)
+        # The stepper only advances ir_progress to HOLDER_PRELIMINARY_REVIEW when the
+        # approval dates are actually edited, so an officer revisiting the stepper with
+        # dates already saved can reach this step while still PRELIMINARY_APPROVED.
+        if inspection_record.ir_progress not in {
+            IRProgressEnum.PRELIMINARY_APPROVED,
+            IRProgressEnum.HOLDER_PRELIMINARY_REVIEW,
+        }:
+            raise UnprocessableEntityError(
+                "IR can only continue preliminary review from an approved preliminary record"
+            )
+        updated_ir = InspectionRecordModel.update_inspection_record(
+            inspection_record_id=inspection_record_id,
+            ir_update_data={"ir_progress": IRProgressEnum.PRELIMINARY_DRAFTING},
+        )
+        return updated_ir
+
+    @classmethod
     def reset_field(
         cls, inspection_id: int, inspection_record_id: int, field_name: str
     ):

--- a/compliance-api/src/compliance_api/services/inspection_record/inspection_record_approval.py
+++ b/compliance-api/src/compliance_api/services/inspection_record/inspection_record_approval.py
@@ -151,9 +151,16 @@ class InspectionRecordApprovalService:
                 ir_update_data["action_required_by_rp"] = ir_data.get(
                     "action_required_by_rp"
                 )
-            if field_name != "is_active":
+            # Recording the approval dates is what moves a freshly approved preliminary
+            # IR into holder review. Any later edit to those dates must not drag the
+            # record back from a stage it has already advanced past, so only apply the
+            # transition when the record is actually sitting at PRELIMINARY_APPROVED.
+            if (
+                field_name != "is_active"
+                and inspection_record.ir_progress == IRProgressEnum.PRELIMINARY_APPROVED
+            ):
                 ir_update_data["ir_progress"] = IRProgressEnum.HOLDER_PRELIMINARY_REVIEW
-                # Update ir_progress to HOLDER_PRELIMINARY_REVIEW
+            if ir_update_data:
                 InspectionRecordModel.update_inspection_record(
                     inspection_record_id=inspection_record_id,
                     ir_update_data=ir_update_data,
@@ -161,6 +168,45 @@ class InspectionRecordApprovalService:
                 )
 
         return updated_approval
+
+    @classmethod
+    def reopen(cls, inspection_id, inspection_record_id, approval_id):
+        """Reopen an issued/approved IR: clear date_issued, revert ir_progress and deactivate the approval.
+
+        Performed atomically so ir_progress can never regress without the
+        corresponding approval being deactivated (or vice versa).
+        """
+        inspection = ServiceUtils.inspection_exist_check(inspection_id)
+        inspection_record = ServiceUtils.inspection_record_exist_check(
+            inspection_record_id
+        )
+        ServiceUtils.access_check_update_for_inspection(inspection)
+        latest_approval = InspectionRecordApprovalModel.get_latest_approval_by_ir(
+            inspection_record_id
+        )
+        if not latest_approval or latest_approval.id != approval_id:
+            raise UnprocessableEntityError(
+                "Given approval id does not match the latest approval request"
+            )
+        if latest_approval.approval_status != IRApprovalStatusEnum.APPROVED:
+            raise UnprocessableEntityError("Only an approved IR can be reopened")
+        ir_progress = (
+            IRProgressEnum.PRELIMINARY_DRAFTING
+            if inspection_record.ir_status_id == IRStatusEnum.PRELIMINARY.value
+            else IRProgressEnum.FINALIZING_RECORD
+        )
+        with session_scope() as session:
+            updated_ir = InspectionRecordModel.update_inspection_record(
+                inspection_record_id=inspection_record_id,
+                ir_update_data={"ir_progress": ir_progress, "date_issued": None},
+                session=session,
+            )
+            InspectionRecordApprovalModel.update_approval(
+                approval_id=approval_id,
+                approval_update_data={"is_active": False},
+                session=session,
+            )
+        return updated_ir
 
     @classmethod
     def update_approval_status(

--- a/compliance-web/src/components/App/Inspections/Profile/Reports/OfficerSteppr/OfficerStepper.tsx
+++ b/compliance-web/src/components/App/Inspections/Profile/Reports/OfficerSteppr/OfficerStepper.tsx
@@ -6,7 +6,7 @@ import PreliminaryReview from "./PreliminaryReview";
 import RegPartyResponse from "./RegPartyResponse";
 import IRVersionSelect from "./IRVersionSelect";
 import {
-  useUpdateInspectionRecord,
+  useContinuePreliminaryReview,
   useUpdateIRApproval,
   useUpdateIRReportToFinal,
 } from "@/hooks/useInspectionReports";
@@ -81,8 +81,8 @@ export default function OfficerStepper() {
   const { mutate: updateIRReportToFinal, isPending: isReportFinalPending } =
     useUpdateIRReportToFinal(onSuccessIRReport);
 
-  const { mutate: updateInspectionRecord, isPending: isInspectionRecordPending } =
-    useUpdateInspectionRecord(onSuccessIRReport);
+  const { mutate: continuePreliminaryReview, isPending: isInspectionRecordPending } =
+    useContinuePreliminaryReview(onSuccessIRReport);
 
   const onUpdateIRApprovalStep = async (
     approvalPayloads: InspectionRecordApprovalPayload[]
@@ -106,13 +106,9 @@ export default function OfficerStepper() {
         inspectionRecordId: inspectionReportsData?.id ?? 0,
       });
     } else {
-      updateInspectionRecord({
+      continuePreliminaryReview({
         inspectionId: inspectionData?.id ?? 0,
         inspectionRecordId: inspectionReportsData?.id ?? 0,
-        updateRecord: {
-          field_name: "ir_progress",
-          value: IRProgressEnum.PRELIMINARY_DRAFTING,
-        },
       });
     }
   };

--- a/compliance-web/src/components/App/Inspections/Profile/Reports/ReopenIRModal.tsx
+++ b/compliance-web/src/components/App/Inspections/Profile/Reports/ReopenIRModal.tsx
@@ -2,15 +2,9 @@ import { DialogContent, Typography } from "@mui/material";
 import ModalTitleBar from "@/components/Shared/Modals/ModalTitleBar";
 import ModalActions from "@/components/Shared/Modals/ModalActions";
 import { FC } from "react";
-import {
-  useResetInspectionRecord,
-  useUpdateInspectionRecord,
-  useUpdateIRApproval,
-} from "@/hooks/useInspectionReports";
+import { useReopenIRApproval } from "@/hooks/useInspectionReports";
 import { useReportStore } from "./reportStore";
 import { InspectionRecord } from "@/models/InspectionRecord";
-import { IRProgressEnum } from "@/utils/constants";
-import { notify } from "@/store/snackbarStore";
 
 type ReopenIRModalProps = {
   onSubmit: (message: string) => void;
@@ -21,50 +15,20 @@ const ReopenIRModal: FC<ReopenIRModalProps> = ({ onSubmit, previousApprovalId })
   const { inspectionData, inspectionReportsData, setInspectionReportsData } =
     useReportStore();
 
-  const handleOnUpdateSuccess = (data: InspectionRecord) => {
+  const handleOnReopenSuccess = (data: InspectionRecord) => {
     setInspectionReportsData(data);
     onSubmit("Inspection Record Reopened");
   };
 
-  const handleOnResetSuccess = (data: InspectionRecord) => {
-    setInspectionReportsData(data);
-    notify.success("Enforcement summary updated");
-  };
-
-  const { mutate: updateInspectionRecord, isPending } =
-    useUpdateInspectionRecord(handleOnUpdateSuccess);
-
-  const { mutate: updateIRApproval } =
-    useUpdateIRApproval(handleOnUpdateSuccess);
-
-  const { mutate: resetInspectionRecord } =
-    useResetInspectionRecord(handleOnResetSuccess);
+  const { mutate: reopenIRApproval, isPending } =
+    useReopenIRApproval(handleOnReopenSuccess);
 
   const onSubmitHandler = () => {
-    resetInspectionRecord({
+    reopenIRApproval({
       inspectionId: inspectionData?.id ?? 0,
       inspectionRecordId: inspectionReportsData?.id ?? 0,
-      resetPayload: {
-        field_name: "date_issued",
-      },
+      approvalId: previousApprovalId ?? 0,
     });
-    updateInspectionRecord({
-      inspectionId: inspectionData?.id ?? 0,
-      inspectionRecordId: inspectionReportsData?.id ?? 0,
-      updateRecord: {
-        field_name: "ir_progress",
-        value: IRProgressEnum.FINALIZING_RECORD,
-      },
-    });
-    updateIRApproval({
-       inspectionId: inspectionData?.id ?? 0,
-        inspectionRecordId: inspectionReportsData?.id ?? 0,
-        approvalId: previousApprovalId ?? 0,
-        approvalPayload: {
-          field_name: "is_active",
-          value: "false",
-        },
-    })
   };
 
   return (

--- a/compliance-web/src/hooks/useInspectionReports.tsx
+++ b/compliance-web/src/hooks/useInspectionReports.tsx
@@ -134,6 +134,34 @@ const updateIRApprovalStatus = ({
   });
 };
 
+const continuePreliminaryReview = ({
+  inspectionId,
+  inspectionRecordId,
+}: {
+  inspectionId: number;
+  inspectionRecordId: number;
+}) => {
+  return request({
+    url: `/inspections/${inspectionId}/inspection-records/${inspectionRecordId}/continue-preliminary-review`,
+    method: "patch",
+  });
+};
+
+const reopenIRApproval = ({
+  inspectionId,
+  inspectionRecordId,
+  approvalId,
+}: {
+  inspectionId: number;
+  inspectionRecordId: number;
+  approvalId: number;
+}) => {
+  return request({
+    url: `/inspections/${inspectionId}/inspection-records/${inspectionRecordId}/approvals/${approvalId}/reopen`,
+    method: "patch",
+  });
+};
+
 const updateIRReportToFinal = ({
   inspectionId,
   inspectionRecordId,
@@ -237,6 +265,20 @@ export const useUpdateIRApproval = (onSuccess: OnSuccessType) => {
 export const useUpdateIRApprovalStatus = (onSuccess: OnSuccessType) => {
   return useMutation({
     mutationFn: updateIRApprovalStatus,
+    onSuccess,
+  });
+};
+
+export const useContinuePreliminaryReview = (onSuccess: OnSuccessType) => {
+  return useMutation({
+    mutationFn: continuePreliminaryReview,
+    onSuccess,
+  });
+};
+
+export const useReopenIRApproval = (onSuccess: OnSuccessType) => {
+  return useMutation({
+    mutationFn: reopenIRApproval,
     onSuccess,
   });
 };


### PR DESCRIPTION
ir_progress was exposed through the generic single-field PATCH endpoint, letting callers overwrite an inspection record's workflow stage without the matching approval record ever changing. Remove it from the allowed fields so every transition goes through a service that keeps the two in step.

Replace the three independent, unawaited mutations behind the reopen modal with a single atomic reopen endpoint, so the stage can no longer regress without the approval being deactivated (or vice versa) when one call fails or races.

Move the stepper's "Continue with Preliminary IR" option onto its own endpoint that validates the record is at an approved preliminary stage before sending it back to drafting.

Stop approval date edits from unconditionally re-stamping HOLDER_PRELIMINARY_REVIEW. Recording the send date still advances a freshly approved preliminary IR, but a later correction no longer drags a record backwards from a stage it has already passed. The action_required_by_rp rebuild is decoupled so it still runs regardless of stage.

Ref COMP-910