### PR TITLE
fix(compliance-api): ignore deleted enforcement actions in pending items (COMP-909)

### DIFF
--- a/compliance-api/src/compliance_api/models/charge_recommendation.py
+++ b/compliance-api/src/compliance_api/models/charge_recommendation.py
@@ -106,10 +106,14 @@ class ChargeRecommendationInspectionRequirementMap(BaseModelVersioned):
     @with_session
     def delete_by_charge_recommendation_id(cls, charge_recommendation_id, session=None):
         """Delete all charge recommendation requirement maps by charge recommendation id."""
-        session.query(cls).filter(
-            cls.charge_recommendation_id == charge_recommendation_id
-        ).update(DELETE_DIC_PARAMS)
-        session.commit()
+        maps = session.query(cls).filter(
+            cls.charge_recommendation_id == charge_recommendation_id,
+            cls.is_active.is_(True),
+            cls.is_deleted.is_(False),
+        )
+        for map_item in maps:
+            map_item.update(DELETE_DIC_PARAMS, commit=False)
+        session.flush()
 
     @classmethod
     @with_session

--- a/compliance-api/src/compliance_api/services/inspection.py
+++ b/compliance-api/src/compliance_api/services/inspection.py
@@ -513,17 +513,34 @@ class InspectionService:
             pending_items.append(pending_inspection_record)
 
         # OPTIMIZATION: Single query with all outer joins to fetch everything at once
-        # Aliases for clarity
+        # Aliases for clarity. The enforcement action maps are pulled in through
+        # subqueries so that both the map row and the enforcement record it points to
+        # are filtered on is_active/is_deleted. Without the check on the record itself,
+        # a deleted enforcement action (eg. a deleted warning letter) is still reported
+        # as pending and blocks the closure of the inspection.
         req = aliased(InspectionRequirementModel)
         enf_map = aliased(InspectionReqEnforcementMapModel)
         enf_action = aliased(EnforcementActionOptionModel)
-        order_map = aliased(OrderInspectionRequirementMapModel)
-        order = aliased(OrderModel)
-        wl_map = aliased(WarningLetterInspectionRequirementMapModel)
-        warning_letter = aliased(WarningLetterModel)
-        ap_map = aliased(AdministrativePenaltyInspectionRequirementMapModel)
-        vt_map = aliased(ViolationTicketInspectionRequirementMapModel)
-        cr_map = aliased(ChargeRecommendationInspectionRequirementMapModel)
+        order_map = _get_live_order_map_sub_query()
+        wl_map = _get_live_warning_letter_map_sub_query()
+        ap_map = _get_live_requirement_map_sub_query(
+            AdministrativePenaltyInspectionRequirementMapModel,
+            AdministrativePenaltyModel,
+            "administrative_penalty_id",
+            "live_administrative_penalty_map",
+        )
+        vt_map = _get_live_requirement_map_sub_query(
+            ViolationTicketInspectionRequirementMapModel,
+            ViolationTicketModel,
+            "violation_ticket_id",
+            "live_violation_ticket_map",
+        )
+        cr_map = _get_live_requirement_map_sub_query(
+            ChargeRecommendationInspectionRequirementMapModel,
+            ChargeRecommendationModel,
+            "charge_recommendation_id",
+            "live_charge_recommendation_map",
+        )
 
         # Build the comprehensive query
         results = (
@@ -532,15 +549,15 @@ class InspectionService:
                 req.summary.label("requirement_summary"),
                 enf_action.id.label("enforcement_action_id"),
                 enf_action.name.label("enforcement_action_name"),
-                order.order_number.label("order_number"),
-                order.order_status.label("order_status"),
-                warning_letter.warning_letter_number.label("warning_letter_number"),
-                warning_letter.status.label("warning_letter_status"),
-                order_map.id.label("order_map_id"),
-                wl_map.id.label("wl_map_id"),
-                ap_map.id.label("ap_map_id"),
-                vt_map.id.label("vt_map_id"),
-                cr_map.id.label("cr_map_id"),
+                order_map.c.order_number.label("order_number"),
+                order_map.c.order_status.label("order_status"),
+                wl_map.c.warning_letter_number.label("warning_letter_number"),
+                wl_map.c.warning_letter_status.label("warning_letter_status"),
+                order_map.c.map_id.label("order_map_id"),
+                wl_map.c.map_id.label("wl_map_id"),
+                ap_map.c.map_id.label("ap_map_id"),
+                vt_map.c.map_id.label("vt_map_id"),
+                cr_map.c.map_id.label("cr_map_id"),
             )
             .select_from(req)
             .join(
@@ -555,53 +572,41 @@ class InspectionService:
             .outerjoin(
                 order_map,
                 and_(
-                    order_map.inspection_requirement_id == req.id,
+                    order_map.c.requirement_id == req.id,
                     enf_map.enforcement_action_id
                     == EnforcementActionOptionEnum.ORDER.value,
-                    order_map.is_active.is_(True),
-                    order_map.is_deleted.is_(False),
                 ),
             )
-            .outerjoin(order, order.id == order_map.order_id)
             .outerjoin(
                 wl_map,
                 and_(
-                    wl_map.inspection_requirement_id == req.id,
+                    wl_map.c.requirement_id == req.id,
                     enf_map.enforcement_action_id
                     == EnforcementActionOptionEnum.WARNING_LETTER.value,
-                    wl_map.is_active.is_(True),
-                    wl_map.is_deleted.is_(False),
                 ),
             )
-            .outerjoin(warning_letter, warning_letter.id == wl_map.warning_letter_id)
             .outerjoin(
                 ap_map,
                 and_(
-                    ap_map.inspection_requirement_id == req.id,
+                    ap_map.c.requirement_id == req.id,
                     enf_map.enforcement_action_id
                     == EnforcementActionOptionEnum.ADMINISTRATIVE_PENALTY_RECOMMENDATION.value,
-                    ap_map.is_active.is_(True),
-                    ap_map.is_deleted.is_(False),
                 ),
             )
             .outerjoin(
                 vt_map,
                 and_(
-                    vt_map.inspection_requirement_id == req.id,
+                    vt_map.c.requirement_id == req.id,
                     enf_map.enforcement_action_id
                     == EnforcementActionOptionEnum.VIOLATION_TICKET.value,
-                    vt_map.is_active.is_(True),
-                    vt_map.is_deleted.is_(False),
                 ),
             )
             .outerjoin(
                 cr_map,
                 and_(
-                    cr_map.inspection_requirement_id == req.id,
+                    cr_map.c.requirement_id == req.id,
                     enf_map.enforcement_action_id
                     == EnforcementActionOptionEnum.CHARGE_RECOMMENDATION.value,
-                    cr_map.is_active.is_(True),
-                    cr_map.is_deleted.is_(False),
                 ),
             )
             .filter(
@@ -656,6 +661,87 @@ class InspectionService:
                     seen_item_numbers.add(item_number)
 
         return pending_items
+
+
+def _get_live_requirement_map_sub_query(
+    map_model, enforcement_model, enforcement_id_column: str, name: str
+):
+    """Get the requirement mappings whose map row and enforcement record are both live.
+
+    Args:
+        map_model: The enforcement action <-> inspection requirement map model
+        enforcement_model: The enforcement action model the map points to
+        enforcement_id_column (str): Foreign key column on the map model
+        name (str): Name of the resulting subquery
+
+    Returns:
+        A subquery with the map id and the inspection requirement id
+    """
+    return (
+        db.session.query(
+            map_model.id.label("map_id"),
+            map_model.inspection_requirement_id.label("requirement_id"),
+        )
+        .join(
+            enforcement_model,
+            enforcement_model.id == getattr(map_model, enforcement_id_column),
+        )
+        .filter(
+            map_model.is_active.is_(True),
+            map_model.is_deleted.is_(False),
+            enforcement_model.is_active.is_(True),
+            enforcement_model.is_deleted.is_(False),
+        )
+        .subquery(name)
+    )
+
+
+def _get_live_order_map_sub_query():
+    """Get the order mappings whose map row and order are both live."""
+    return (
+        db.session.query(
+            OrderInspectionRequirementMapModel.id.label("map_id"),
+            OrderInspectionRequirementMapModel.inspection_requirement_id.label(
+                "requirement_id"
+            ),
+            OrderModel.order_number.label("order_number"),
+            OrderModel.order_status.label("order_status"),
+        )
+        .join(OrderModel, OrderModel.id == OrderInspectionRequirementMapModel.order_id)
+        .filter(
+            OrderInspectionRequirementMapModel.is_active.is_(True),
+            OrderInspectionRequirementMapModel.is_deleted.is_(False),
+            OrderModel.is_active.is_(True),
+            OrderModel.is_deleted.is_(False),
+        )
+        .subquery("live_order_map")
+    )
+
+
+def _get_live_warning_letter_map_sub_query():
+    """Get the warning letter mappings whose map row and warning letter are both live."""
+    return (
+        db.session.query(
+            WarningLetterInspectionRequirementMapModel.id.label("map_id"),
+            WarningLetterInspectionRequirementMapModel.inspection_requirement_id.label(
+                "requirement_id"
+            ),
+            WarningLetterModel.warning_letter_number.label("warning_letter_number"),
+            WarningLetterModel.status.label("warning_letter_status"),
+        )
+        .join(
+            WarningLetterModel,
+            WarningLetterModel.id
+            == WarningLetterInspectionRequirementMapModel.warning_letter_id,
+        )
+        .filter(
+            WarningLetterInspectionRequirementMapModel.is_active.is_(True),
+            WarningLetterInspectionRequirementMapModel.is_deleted.is_(False),
+            WarningLetterModel.is_active.is_(True),
+            WarningLetterModel.is_deleted.is_(False),
+        )
+        .subquery("live_warning_letter_map")
+    )
 
 
 def _validate_inspection_can_be_closed(pending_items: list):

--- a/compliance-api/src/compliance_api/services/inspection_requirement.py
+++ b/compliance-api/src/compliance_api/services/inspection_requirement.py
@@ -1558,7 +1558,8 @@ def _validate_and_delete_enforcement_action(
     Validate and delete a specific enforcement action type.
 
     @param enforcement_action_config: Configuration dict containing model, status_field,
-                                    allowed_status, map_field, update_method, and error_message
+                                    allowed_status, map_field, update_method,
+                                    map_delete_method and error_message
     @param requirement_id: Requirement id
     @param inspection_id: Inspection id
     @param session: Database session
@@ -1573,6 +1574,7 @@ def _validate_and_delete_enforcement_action(
     )
     map_field = enforcement_action_config["map_field"]
     update_method = enforcement_action_config["update_method"]
+    map_delete_method = enforcement_action_config["map_delete_method"]
     error_message = enforcement_action_config["error_message"]
 
     # Get all enforcement actions of this type for the inspection
@@ -1593,8 +1595,10 @@ def _validate_and_delete_enforcement_action(
     ):
         raise UnprocessableEntityError(error_message)
 
-    # Delete all enforcement actions of this type for this requirement
+    # Delete all enforcement actions of this type for this requirement along with their
+    # requirement mappings.
     for action in requirement_enforcement_actions:
+        map_delete_method(action.id, session)
         update_method(action.id, {"is_deleted": True, "is_active": False}, session)
 
 
@@ -1631,6 +1635,7 @@ def _check_enforcement_action_existennce(
             "allowed_status": OrderProgressEnum.DRAFTING,
             "map_field": "order_requirement_maps",
             "update_method": OrderModel.update_order,
+            "map_delete_method": OrderInspectionRequirementMapModel.delete_by_order,
             "error_message": "You cannot change enforcement action as order exists and is not in DRAFTING status.",
         },
         EnforcementActionOptionEnum.WARNING_LETTER.value: {
@@ -1639,6 +1644,9 @@ def _check_enforcement_action_existennce(
             "allowed_status": WarningLetterProgressEnum.DRAFTING,
             "map_field": "warning_letter_requirement_maps",
             "update_method": WarningLetterModel.update_warning_letter,
+            "map_delete_method": (
+                WarningLetterInspectionRequirementMapModel.delete_by_warning_letter
+            ),
             "error_message": (
                 "You cannot change enforcement action as warning letter exists and is not in DRAFTING status."
             ),
@@ -1653,6 +1661,9 @@ def _check_enforcement_action_existennce(
             ),
             "map_field": "administrative_penalty_requirement_maps",
             "update_method": AdministrativePenaltyModel.update_administrative_penalty,
+            "map_delete_method": (
+                AdministrativePenaltyInspectionRequirementMapModel.delete_by_administrative_penalty
+            ),
             "error_message": (
                 "You cannot change enforcement action as administrative penalty exists and is not in DRAFTING status."
             ),
@@ -1663,6 +1674,9 @@ def _check_enforcement_action_existennce(
             "allowed_status": ViolationTicketStatusEnum.ISSUED,
             "map_field": "violation_ticket_requirement_maps",
             "update_method": ViolationTicketModel.update_violation_ticket,
+            "map_delete_method": (
+                ViolationTicketInspectionRequirementMapModel.delete_by_violation_ticket_id
+            ),
             "error_message": (
                 "You cannot change enforcement action as violation ticket exists and is not in ISSUED status."
             ),
@@ -1673,6 +1687,9 @@ def _check_enforcement_action_existennce(
             "allowed_status": ChargeRecommendationStatusEnum.DRAFTING,
             "map_field": "charge_recommendation_requirement_maps",
             "update_method": ChargeRecommendationModel.update_charge_recommendation,
+            "map_delete_method": (
+                ChargeRecommendationInspectionRequirementMapModel.delete_by_charge_recommendation_id
+            ),
             "error_message": (
                 "You cannot change enforcement action as charge recommendation exists and is not in DRAFTING status."
             ),

--- a/compliance-api/tests/integration/api/test_inspection.py
+++ b/compliance-api/tests/integration/api/test_inspection.py
@@ -19,6 +19,8 @@ from compliance_api.models.compliance_finding import ComplianceFindingOptionEnum
 from compliance_api.models.db import session_scope
 from compliance_api.models.enforcement_action import EnforcementActionOptionEnum
 from compliance_api.models.inspection import InspectionAttendanceOptionEnum, InspectionStatusEnum
+from compliance_api.models.warning_letter import (
+    WarningLetter, WarningLetterInspectionRequirementMap, WarningLetterStatusEnum)
 from compliance_api.services import InspectionService
 from tests.utilities.factory_scenario import AgencyScenario, InspectionScenario, StaffScenario, TokenJWTClaims
 from tests.utilities.factory_utils import factory_auth_header
@@ -602,6 +604,88 @@ def test_inspection_close_as_note(
         req2_enf_maps[0].enforcement_action_id
         == EnforcementActionOptionEnum.ORDER.value
     )
+
+
+def test_pending_items_excludes_deleted_warning_letters(
+    client,
+    jwt,
+    created_staff,
+    mocker,
+    created_case_file,
+    mock_track_service,
+):
+    """A deleted warning letter should not be reported as a pending item."""
+    contains_role = mocker.patch("compliance_api.auth.jwt.contains_role")
+    contains_role.return_value = True
+    mocker.patch(
+        "compliance_api.services.service_utils.ServiceUtils.access_check_update_for_inspection",
+        return_value=None,
+    )
+    inspection_data = copy.copy(InspectionScenario.default_value.value)
+    inspection_data.update(
+        {
+            "case_file_id": created_case_file.id,
+            "primary_officer_id": created_staff.id,
+            "initiation_id": 1,
+            "start_date": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        }
+    )
+    created_inspection = InspectionService.create(inspection_data)
+
+    with session_scope() as session:
+        requirement = InspectionRequirementModel(
+            inspection_id=created_inspection.id,
+            summary="Requirement with two warning letters",
+            topic_id=1,
+            sort_order=1,
+            compliance_finding_id=ComplianceFindingOptionEnum.OUT.value,
+        )
+        session.add(requirement)
+        session.flush()
+        session.add(
+            InspectionReqEnforcementMap(
+                requirement_id=requirement.id,
+                enforcement_action_id=EnforcementActionOptionEnum.WARNING_LETTER.value,
+            )
+        )
+        issued_warning_letter = WarningLetter(
+            inspection_id=created_inspection.id,
+            warning_letter_number="WN-TEST-001",
+            issuing_officer_id=created_staff.id,
+            status=WarningLetterStatusEnum.ISSUED,
+        )
+        # Deleted warning letter whose requirement mapping is still around
+        deleted_warning_letter = WarningLetter(
+            inspection_id=created_inspection.id,
+            warning_letter_number="WN-TEST-002",
+            issuing_officer_id=created_staff.id,
+            status=WarningLetterStatusEnum.CREATED,
+            is_active=False,
+            is_deleted=True,
+        )
+        session.add(issued_warning_letter)
+        session.add(deleted_warning_letter)
+        session.flush()
+        session.add(
+            WarningLetterInspectionRequirementMap(
+                warning_letter_id=issued_warning_letter.id,
+                inspection_requirement_id=requirement.id,
+            )
+        )
+        session.add(
+            WarningLetterInspectionRequirementMap(
+                warning_letter_id=deleted_warning_letter.id,
+                inspection_requirement_id=requirement.id,
+            )
+        )
+
+    pending_items = InspectionService.get_pending_items(created_inspection.id)
+    warning_letter_items = [
+        item
+        for item in pending_items
+        if item["item"]["id"] == EnforcementActionOptionEnum.WARNING_LETTER.value
+    ]
+    assert warning_letter_items == []
 
 
 def test_inspection_delete(

--- a/compliance-api/tests/integration/api/test_inspection_requirement.py
+++ b/compliance-api/tests/integration/api/test_inspection_requirement.py
@@ -300,6 +300,45 @@ def test_delete_inspection_requirement(
     assert deleted_req is None
 
 
+def test_change_enforcement_action_deletes_warning_letter_requirement_maps(
+    client,
+    auth_header_super_user,
+    db,
+    created_inspection,
+    created_warning_letter,
+    created_warning_letter_inspection_requirement,
+):
+    """Changing the enforcement action deletes the warning letter and its requirement maps."""
+    update_data = copy.copy(InspectionRequirementScenario.default_value.value)
+    update_data["summary"] = "Requirement no longer needs a warning letter"
+    # Drop WARNING_LETTER (4) from the requirement
+    update_data["enforcement_action_ids"] = [2]
+    url = urljoin(
+        API_BASE_URL,
+        f"{created_inspection.id}/requirements/"
+        f"{created_warning_letter_inspection_requirement.id}",
+    )
+    result = client.patch(
+        url,
+        data=json.dumps(update_data),
+        headers=auth_header_super_user,
+    )
+    assert result.status_code == HTTPStatus.OK
+    assert WarningLetterModel.find_by_id(created_warning_letter.id) is None
+    # The requirement mappings must be soft deleted along with the warning letter,
+    # otherwise the orphaned maps keep the warning letter reported as a pending item.
+    requirement_maps = (
+        db.session.query(WarningLetterInspectionRequirementMap)
+        .filter_by(warning_letter_id=created_warning_letter.id)
+        .all()
+    )
+    assert requirement_maps
+    assert all(
+        requirement_map.is_deleted and not requirement_map.is_active
+        for requirement_map in requirement_maps
+    )
+
+
 def test_delete_requirement_deletes_sole_linked_draft_order(
     client,
     auth_header_super_user,


### PR DESCRIPTION
Filter pending-item lookups on both the requirement map and the enforcement record so deleted actions no longer block inspection closure, and soft delete the requirement maps when an enforcement action is removed.

Ref COMP-909